### PR TITLE
update PR template for #66

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-*Delete these pull request guideline instructions before submitting*
+## Pull Request Guidelines
 
-Before you submit this pull request be sure to
+Thank you for contributing! If this pull request is a work in progress, please mark it as a Draft by clicking on the
+green arrow next to `Create pull request` and selecting `Create draft pull request`. For substantive changes to the
+standards we recommend that you first 
+[create an issue](https://github.com/openmodelingfoundation/openmodelingfoundation.github.io/issues) to discuss the
+changes with the OMF community. 
 
-- [ ] label the PR appropriately
-- [ ] assign it to a suitable project
-- [ ] request reviewers (optional)
-- [ ] associate the PR with one or more issues using [references](https://help.github.com/en/github/writing-on-github/autolinked-references-and-urls#issues-and-pull-requests) (optional)
-
-If you are an external contributor you may not have permission to assign labels, projects or reviewers during the pull request creation phase or after. If you don't have permission, don't worry someone else will assign labels, projects and reviewers for you.
+Otherwise, please replace this boilerplate text with a clearly stated rationale for the proposed changes in this text
+area.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,5 @@
 ## Pull Request Guidelines
 
-Thank you for contributing! If this pull request is a work in progress, please mark it as a Draft by clicking on the
-green arrow next to `Create pull request` and selecting `Create draft pull request`. For substantive changes to the
-standards we recommend that you first 
-[create an issue](https://github.com/openmodelingfoundation/openmodelingfoundation.github.io/issues) to discuss the
-changes with the OMF community. 
+If this pull request is a work in progress, please mark it as a Draft by clicking on the green arrow next to `Create pull request` and selecting `Create draft pull request`. For substantive changes to the standards we recommend that you first [create an issue on the relevant standards page](https://openmodelingfoundation.github.io/standards/) to discuss the changes with the OMF community. 
 
-Otherwise, please replace this boilerplate text with a clearly stated rationale for the proposed changes in this text
-area.
+Otherwise, please include a clear rationale for the proposed changes in this text area. Thank you for contributing to the OMF standards repository!


### PR DESCRIPTION
replace existing pull request template with actionable verbiage since most contributors (including editors) won't have permissions to label or assign the PR to a project.