### PR TITLE
Update expanded FAIR acronym member, reproducible to reusable

### DIFF
--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -87,7 +87,7 @@ replicable, interoperable, and reliable models. These standards include, but are
 
 - **Discoverability and Accessibility:** Standards for accessibility
   ensure that model code is available in FAIR-aligned digital
-  repositories (Findable, Accessible, Interoperable, Reproducible) and
+  repositories (Findable, Accessible, Interoperable, Reusable) and
   that model developers receive public recognition and professional
   credit for code they make accessible in this way.
 


### PR DESCRIPTION
### Objective
Use word reusable instead of reproducible when expanding the acronym FAIR in the charter.

Given my new coming to the group, I am not sure if this topic has already been discussed and this is a moot point. In reading the charter, I see the work _reproducible_ is used instead of _reusable_. Reusable is the _accepted_ 'R' in FAIR. 

Reference: 
"namely, that all research objects should be Findable, Accessible, Interoperable and Reusable (FAIR) both for machines and for people."

Wilkinson, M., Dumontier, M., Aalbersberg, I. et al. The FAIR Guiding Principles for scientific data management and stewardship. Sci Data 3, 160018 (2016). https://doi.org/10.1038/sdata.2016.18


### Changes

- R in FAIR now reusable in charter. Previously reproducible.
