### PR TITLE
updated charter title

### DIFF
--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -1,13 +1,12 @@
 ---
 
-title: "Open Modeling Foundation Charter v2021.12"
+title: "Open Modeling Foundation Charter"
 linkTitle: "Charter"
 weight: 1
-keywords: "Open Modeling Foundation Charter Governance"
 
 ---
 
-_Adopted at international founding meeting December 7-8, 2021_
+_Adopted December 8, 2021_
 
 ## Vision
 

--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -1,10 +1,13 @@
 ---
-title: "Charter"
-weight: 1
----
-# Open Modeling Foundation Charter
 
-# _Version 2021.12 adopted at international founding meeting 7/8 December 2021_
+title: "Open Modeling Foundation Charter v2021.12"
+linkTitle: "Charter"
+weight: 1
+keywords: "Open Modeling Foundation Charter Governance"
+
+---
+
+_Adopted at international founding meeting December 7-8, 2021_
 
 ## Vision
 

--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -4,7 +4,7 @@ weight: 1
 ---
 # Open Modeling Foundation Charter
 
-# _Adopted across the world, 7/8 December 2021_
+# _Version 2021.12 adopted at international founding meeting 7/8 December 2021_
 
 ## Vision
 

--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -2,10 +2,9 @@
 title: "Charter"
 weight: 1
 ---
+# Open Modeling Foundation Charter
 
-# Open Modeling Foundation
-
-# _Organizational Charter - Draft 0.9_
+# _Adopted across the world, 7/8 December 2021_
 
 ## Vision
 


### PR DESCRIPTION
It is no longer a draft. It is officially adopted. Would it mess up the links if we just used Open Modeling Foundation Charter in the title so there is not the redundancy on the page?
