### PR TITLE
Revise working group description and voting

### DIFF
--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -256,17 +256,15 @@ identifies a substitute from the EC if unable to do so.
 
 Voting members of the Executive Committee are composed of:
 
-- the leaders of each Working Group and
+- no more than two co-chairs of each Working Group and
 - three representatives elected from the Members Council.
 
-Elected members of the EC serve staggered three-year terms.
+Elected representatives to the EC from the Members Council serve staggered three-year terms.
 
 Non-voting members of the Executive Committee are composed of:
 
 - the Executive Director (who may vote to break ties in the EC),
 - the Administrative Coordinator,
-- a representative of the Cyberinfrastructure and Education Support team, and
-- a representative from the OMF Early Career Scholars
 
 The Executive Committee ensures that the activities of the Open Modeling Foundation further its vision, mission, and
 goals as expressed in this charter. It oversees all elections and any other selection of individuals involved in OMF
@@ -337,44 +335,6 @@ Open Modeling Foundation Working Group. If the Members Council votes to remove a
 removal is effective immediately. There is no appeal to this vote of removal. However, after a period of not less than
 one year, an individual can request to rejoin an Open Modeling Foundation Working Group. Such a request will be
 considered like any new request to join a Working Group.
-
-### Cyberinfrastructure and Technical Support Staff
-
-The Cyberinfrastructure and Technical Support (CTS) staff coordinates development and management of the OMF Science
-Gateway, and online platform for collaborative governance and standards. CTS works to identify or develop tools and
-processes which serve to lower the technical barriers towards adoption of OMF standards, and ways to best deploy these
-tools to enable their use by modeling scientists. CTS staff assist the EOWG in developing online training modules and
-disseminating them on the OMF Gateway.
-
-### Early Career Scholars
-
-The Early Career Scholars helps the Open Modeling Foundation to support student and early career development. The ECS is
-open to any student enrolled in an institution of higher learning (e.g., college or university) or early career scholar.
-The ECS provides input to Working Groups and the Executive Committee. The ECS can organize student-focused programs and
-events, assisted by the Administrative Coordinator and EOWG. Members of the ECS elect a leader to represent the ECS on
-the Executive Committee.
-
-#### Joining and Leaving the Early Career Scholars
-
-Individuals may request to become a member of the Open Modeling Foundation Early Career Scholars by a 
-[written notification of request]({{< param working_group_request_form >}}) to the OMF Administrative Coordinator, with
-approval of the Executive Committee. Any individuals seeking to join the ECS must agree to support the mission, goals,
-ethics, and values of the OMF, as described in this charter and the OMF values statement, to promote OMF approved
-standards, and to provide professional recognition to researchers engaged in standards-based modeling. An individual
-intending to leave the ECS should notify the Administrative Coordinator in writing of this intent.
-
-An individual can be suspended or permanently removed from the Open Modeling Foundation ECS if they are found to engage
-in illegal or unethical practice, violate the Open Modeling Foundation Values, become inactive by failing to participate
-in ECS meetings or other activities for two consecutive years without excused absence, or becoming no longer qualified
-for membership as an ECS. A request to consider removing an ECS member can be made by the ECS leadership in the form of
-a letter to the Executive Committee, describing the reasons why removal should be considered. The Executive Committee
-will review the request, compile relevant information from all parties, and refer the matter to a vote of the Members
-Council with a recommendation to approve or deny the request. A vote of the majority of at least two-thirds of the valid
-votes cast in a meeting at which at least two-thirds of the Members Council participates is needed to remove an
-individual from the Open Modeling Foundation ECS. If the Members Council votes to remove an individual from the ECS,
-removal is effective immediately. There is no appeal to this vote of removal. However, after a period of not less than
-one year, an individual can request to rejoin the Open Modeling Foundation ECS. Such a request will be considered like
-any new request to join the ECS.
 
 ### Open Modeling Foundation Affiliates
 

--- a/content/en/governance/charter/_index.md
+++ b/content/en/governance/charter/_index.md
@@ -256,7 +256,7 @@ identifies a substitute from the EC if unable to do so.
 
 Voting members of the Executive Committee are composed of:
 
-- no more than two co-chairs of each Working Group and
+- one voting representative (chair or co-chair) of each Working Group and
 - three representatives elected from the Members Council.
 
 Elected representatives to the EC from the Members Council serve staggered three-year terms.

--- a/content/en/governance/working-groups.md
+++ b/content/en/governance/working-groups.md
@@ -6,11 +6,13 @@ weight: 100
 
 ## Working Groups
 
-Open Modeling Foundation Working Groups coordinate key activities, enabling a diverse spectrum of modeling scientists to participate directly in OMF activities and self-governance and ensuring that it can fulfill its vision, mission, and goals. Three Working Groups are initially established and described below; additional Working Groups may be established with approval of the Members Council.
+Open Modeling Foundation Working Groups coordinate key activities, enabling a diverse spectrum of modeling scientists to participate directly in OMF activities and self-governance and ensuring that it can fulfill its vision, mission, and goals. Five Working Groups are established and described below; additional Working Groups may be established with approval of the Members Council.
 
 Any modeling scientist can join a Working Group. Working Groups self organize, with support from the Executive Committee, and nominate a Working Group Chair for approval by the Members Council. Working Group Chairs serve for a three-year, renewable term.
 
-Working Groups meet as needed at least once per year either virtually or in person.  
+Working Groups meet as needed at least once per year either virtually or in person.
+
+Working Groups are led by chairs, nominated by the Executive Committee and approved by the Members Council. Working Groups can be led by multiple co-chairs. However, each Working Group only provides a single vote as voting members of the Executive Committee and should either find unanimous consensus for their votes across all co-chairs or abstain.
 
 #### [Click here to join a Working Group]({{< param working_group_request_form >}})
 
@@ -31,6 +33,14 @@ The Education and Outreach Working Group (EOWG) helps OMF member organizations r
 ### Cyberinfrastructure Working Group
 
 The Cyberinfrastructure Working Group (CYWG) coordinates development and management of the OMF Science Gateway, an online platform for collaborative governance and standards. CYWG works to to identify, develop, and enhance tools and processes that lower the technical barriers towards adoption of OMF standards and facilitate their use by modeling scientists. CYWG staff assist the EOWG in developing online training modules and making them available on the OMF Science Gateway.
+
+### Early Career Scholars Working Group
+
+The Early Career Scholars Working Group (ECSWG) helps the Open Modeling Foundation to support student and early career development. The ECSWG is
+open to any student enrolled in an institution of higher learning (e.g., college or university) or other early career scholar.
+The ECSWG provides input to other Working Groups and the Executive Committee. The ECS can organize student-focused programs and
+events, assisted by the Administrative Coordinator and EOWG.
+
 
 ### Additional Working Groups
 

--- a/content/en/governance/working-groups.md
+++ b/content/en/governance/working-groups.md
@@ -12,7 +12,7 @@ Any modeling scientist can join a Working Group. Working Groups self organize, w
 
 Working Groups meet as needed at least once per year either virtually or in person.
 
-Working Groups are led by chairs, nominated by the Executive Committee and approved by the Members Council. Working Groups can be led by multiple co-chairs. However, each Working Group only provides a single vote as voting members of the Executive Committee and should either find unanimous consensus for their votes across all co-chairs or abstain.
+Working Groups are led by chairs, nominated by the Executive Committee and approved by the Members Council. Working Groups can be led by multiple co-chairs. However, each Working Group has a only single vote on the Executive Committee.
 
 #### [Click here to join a Working Group]({{< param working_group_request_form >}})
 


### PR DESCRIPTION
Specify no more than 2 WG co-chairs can vote in the Executive Committee. Remove descriptions of cyberinfrastructure and early career scholars in charter to go along with proposal to redefine them as Working Groups.