### PR TITLE
Fix broken link to working-groups

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -42,7 +42,7 @@ linkTitle = "Open Modeling Foundation"
 {{< blocks/section color="light" >}}
   {{% blocks/feature icon="fas fa-project-diagram" title="How to Participate" url="/contribute" url_text="How to contribute" %}}
   You can [contribute to OMF activities](/contribute/) as a representative of a member organization or
-  as an individual in a [Working Group](/governance/working-groups/).
+  as an individual in a [Working Group](/about/working-groups/).
   {{% /blocks/feature %}}
   
   {{% blocks/feature icon="fas fa-users" title="Community" url="/about/community" %}}


### PR DESCRIPTION
The link before was referencing governance/working-groups which does not exist anymore. 
The correct link should be about/working-groups instead. 

I did not test this locally because I don't have Hugo installed. 

But the link https://www.openmodelingfoundation.org/about/working-groups/ exists and I think this is the one that is meant to be referenced here