### PR TITLE
fix: make sloan logo responsive

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -36,8 +36,8 @@ footer {
     min-height: 160px;
 
     .logo {
-        max-width: 100%;
-        height: 60%;
+        max-width: 60%;
+        height: auto;
     }
 
     a {

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,9 +5,9 @@
                 <a target="_blank" href='https://alliancecan.ca/en'><img class="img-fluid" src="/images/digital-research-alliance-canada.svg" /></a>
             </div>
             <div class='col-6 col-sm-4 text-center my-0 py-0 order-sm-2'>
-                This work was enabled in part by generous support from 
-                <a target="_blank" href='https://alliancecan.ca/en'><u>the Digital Research Alliance</u></a> of Canada
-                and the <a target="_blank" href='https://sloan.org'><u>Alfred P. Sloan Foundation</u></a>.
+                This work was enabled in part by generous support from the <a target="_blank" href='https://sloan.org'><u>Alfred P. Sloan Foundation</u></a>
+                and <a target="_blank" href='https://alliancecan.ca/en'><u>the Digital Research Alliance of Canada</u></a>.
+                <br />
                 {{ with .Site.Params.copyright }}&copy; {{ now.Year }} {{ .}} {{ T "footer_all_rights_reserved" }}{{ end }}
             </div>
             <div class='col-3 col-sm-4 text-xs-center text-right order-sm-3'>


### PR DESCRIPTION
switch to 60% max-width to line up better with DRAC logo