### PR TITLE
build: remove `hugo mod get` step

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,6 @@ jobs:
           HUGO_ENV: "production"
         run: |
           npm install
-          hugo mod get
           hugo --minify --gc
 
       - name: Deploy to Pages

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY . /src/
 
 RUN git config --global --add safe.directory /src
 
-RUN hugo mod get
 RUN npm install
 
 CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ If you don't have docker installed and don't mind installing things in your oper
 - Use hugo commands and npm to build/render the site.
 
 ```bash
-% hugo mod get
 % npm install
 % hugo serve     # dev server without drafts
 # OR

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/openmodelingfoundation/openmodelingfoundation.github.io
 
 go 1.18
 
-require github.com/google/docsy v0.11.0 // indirect
+require github.com/google/docsy v0.11.0
+
+require github.com/google/docsy/dependencies v0.7.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
 github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
`hugo mod get` is unnecessary and causing problems - it will always cause dependencies in go.mod to be updated which breaks things. Unnecessary because `hugo` commands like build and serve will download any modules in go.mod anyways